### PR TITLE
Fix active item color in header menu

### DIFF
--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -1,7 +1,14 @@
 <script>
+	import { page } from '$app/stores';
+
 	let toggled = false;
 	function clickButton() {
 		toggled = !toggled;
+	}
+
+	function getCurrentMenuItemClassName(path) {
+		const currentPath = $page.url.pathname;
+		return path === currentPath ? 'current-menu-item' : ''
 	}
 </script>
 
@@ -20,25 +27,25 @@
 				<ul id="menu-menu" class="menu nav-menu" aria-expanded={toggled ? "true" : "false"}>
 					<li
 						id="menu-item-17"
-						class="menu-item menu-item-type-post_type menu-item-object-page menu-item-home current-menu-item page_item page-item-15 current_page_item menu-item-17"
+						class="menu-item menu-item-type-post_type menu-item-object-page menu-item-home page_item page-item-15 menu-item-17 {getCurrentMenuItemClassName('/')}"
 					>
 						<a href="/" target="_self">Home</a>
 					</li>
 					<li
 						id="menu-item-36"
-						class="menu-item menu-item-type-post_type menu-item-object-page menu-item-36"
+						class="menu-item menu-item-type-post_type menu-item-object-page menu-item-36 {getCurrentMenuItemClassName('/research/')}"
 					>
 						<a href="/research/" target="_self">Research</a>
 					</li>
 					<li
 						id="menu-item-38"
-						class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-38"
+						class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-38 {getCurrentMenuItemClassName('/members/')}"
 					>
 						<a href="/members/" target="_self">Members</a>
 						<ul class="sub-menu">
 							<li
 								id="menu-item-37"
-								class="menu-item menu-item-type-post_type menu-item-object-page menu-item-37"
+								class="menu-item menu-item-type-post_type menu-item-object-page menu-item-37 {getCurrentMenuItemClassName('/members/alumni/')}"
 							>
 								<a href="/members/alumni/" target="_self">Alumni</a>
 							</li>
@@ -46,7 +53,7 @@
 					</li>
 					<li
 						id="menu-item-113"
-						class="menu-item menu-item-type-post_type menu-item-object-page menu-item-113"
+						class="menu-item menu-item-type-post_type menu-item-object-page menu-item-113 {getCurrentMenuItemClassName('/publications/')}"
 					>
 						<a href="/publications/" target="_self">Publications</a>
 					</li>
@@ -60,7 +67,7 @@
 					</li>
 					<li
 						id="menu-item-39"
-						class="menu-item menu-item-type-post_type menu-item-object-page menu-item-39"
+						class="menu-item menu-item-type-post_type menu-item-object-page menu-item-39 {getCurrentMenuItemClassName('/access/')}"
 					>
 						<a href="/access/" target="_self">Access</a>
 					</li>

--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -33,19 +33,19 @@
 					</li>
 					<li
 						id="menu-item-36"
-						class="menu-item menu-item-type-post_type menu-item-object-page menu-item-36 {getCurrentMenuItemClassName('/research/')}"
+						class="menu-item menu-item-type-post_type menu-item-object-page menu-item-36 {getCurrentMenuItemClassName('/research')}"
 					>
 						<a href="/research/" target="_self">Research</a>
 					</li>
 					<li
 						id="menu-item-38"
-						class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-38 {getCurrentMenuItemClassName('/members/')}"
+						class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-38 {getCurrentMenuItemClassName('/members')}"
 					>
 						<a href="/members/" target="_self">Members</a>
 						<ul class="sub-menu">
 							<li
 								id="menu-item-37"
-								class="menu-item menu-item-type-post_type menu-item-object-page menu-item-37 {getCurrentMenuItemClassName('/members/alumni/')}"
+								class="menu-item menu-item-type-post_type menu-item-object-page menu-item-37 {getCurrentMenuItemClassName('/members/alumni')}"
 							>
 								<a href="/members/alumni/" target="_self">Alumni</a>
 							</li>
@@ -53,7 +53,7 @@
 					</li>
 					<li
 						id="menu-item-113"
-						class="menu-item menu-item-type-post_type menu-item-object-page menu-item-113 {getCurrentMenuItemClassName('/publications/')}"
+						class="menu-item menu-item-type-post_type menu-item-object-page menu-item-113 {getCurrentMenuItemClassName('/publications')}"
 					>
 						<a href="/publications/" target="_self">Publications</a>
 					</li>
@@ -67,7 +67,7 @@
 					</li>
 					<li
 						id="menu-item-39"
-						class="menu-item menu-item-type-post_type menu-item-object-page menu-item-39 {getCurrentMenuItemClassName('/access/')}"
+						class="menu-item menu-item-type-post_type menu-item-object-page menu-item-39 {getCurrentMenuItemClassName('/access')}"
 					>
 						<a href="/access/" target="_self">Access</a>
 					</li>


### PR DESCRIPTION
開いているページに関わらず常に「Home」だけが紫色になってしまっていたので、実際に開いているページに対応するメニューに色がつくように修正しました。

`getCurrentMenuItemClassName()`はもっといい名前にできるかもしれません…。

@KoyamaSohei レビューお願いします